### PR TITLE
Do not sort the list of parent directories

### DIFF
--- a/bd.zsh
+++ b/bd.zsh
@@ -21,4 +21,4 @@ bd () {
 _bd () {
   reply=(${=PWD//\// })
 }
-compctl -K _bd bd
+compctl -V directories -K _bd bd


### PR DESCRIPTION
First of all, thanks for you work, bd is very useful! :)

Anyway, I think directories should not be sorted alphabetically when completing the command, this way is easier to find the directory we want to jump to.
