### PR TITLE
Fix handling of paths with white spaces

### DIFF
--- a/bd.zsh
+++ b/bd.zsh
@@ -3,9 +3,17 @@ bd () {
     print -- "usage: $0 <name-of-any-parent-directory>"
     return 1
   } >&2
-  parents=(/ ${=PWD//\// })
+  # Get parents (in reverse order)
+  parents=()
+  num=`echo $PWD | grep -o "/" | wc -l`
+  for i in {$((num+1))..2}
+  do
+    parents=($parents "`echo $PWD | cut -d'/' -f$i`")
+  done
+  parents=($parents "/")
+  # Build dest and 'cd' to it
   dest="./"
-  foreach parent (${(Oa)parents}) # Loop backwards
+  foreach parent (${parents})
   do
     if [[ $1 == $parent ]]
     then
@@ -17,11 +25,13 @@ bd () {
   print -- "bd: Error: No parent directory named '$1'"
   return 1
 }
-
 _bd () {
-  temp=(/ ${=PWD//\// })
-  for e in "${temp[@]}"; do
-    reply=("$e" "${reply[@]}")
+  # Get parents (in reverse order)
+  num=`echo $PWD | grep -o "/" | wc -l`
+  for i in {$((num+1))..2}
+  do
+    reply=($reply "`echo $PWD | cut -d'/' -f$i`")
   done
+  reply=($reply "/")
 }
 compctl -V directories -K _bd bd


### PR DESCRIPTION
I noticed that bd is badly broken when dealing with paths containing white spaces.
Example:

```
# pwd
/home/voria/a/b/c e/d f g
```

If I autocomplete bd:

```
# bd <autocomplete>
g      f      d      e      c      b      a      voria  home   /
```

I can even choose "f" from the list:

```
 # bd f
 # pwd
 /home/voria/a/b/c e
```

To fix this the logic used to get the list of parent directories has to be completely changed.
