### PR TITLE
Fix error "not an identifier" when getting number of parents

### DIFF
--- a/bd.zsh
+++ b/bd.zsh
@@ -5,7 +5,7 @@ bd () {
   } >&2
   # Get parents (in reverse order)
   local parents
-  local num=`echo $PWD | grep -o "/" | wc -l`
+  local num=${#${(ps:/:)${PWD}}}
   local i
   for i in {$((num+1))..2}
   do
@@ -29,7 +29,7 @@ bd () {
 }
 _bd () {
   # Get parents (in reverse order)
-  local num=`echo $PWD | grep -o "/" | wc -l`
+  local num=${#${(ps:/:)${PWD}}}
   local i
   for i in {$((num+1))..2}
   do


### PR DESCRIPTION
Hello,

When I run the script, the following errors appear :
_bd:local:2: not an identifier: 6
or
bd:local:7: not an identifier: 6

So I change the way to get the number of parents and the script works fine.
