### PR TITLE
fixes `curl` url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ of the zsh shell.
 All you need to do is to source `bd.zsh`. Here's the manual installation
 
     mkdir -p $HOME/.zsh/plugins/bd
-    curl https://raw.github.com/Tarrasch/zsh-bd/master/bd.zsh > $HOME/.zsh/plugins/bd/bd.zsh
+    curl https://raw.githubusercontent.com/Tarrasch/zsh-bd/master/bd.zsh > $HOME/.zsh/plugins/bd/bd.zsh
     print -- "\n# zsh-bd\n. \$HOME/.zsh/plugins/bd/bd.zsh" >> $HOME/.zshrc
 
 Restart your shell (or run `zsh`)


### PR DESCRIPTION
Thanks for the plugin! Figured I'd update the installation URL.
