### PR TITLE
Allow the user to provide an integer N to go up N times.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ If you prefer antigen over manual installation
     $ bd b
     $ ls
     c
+    $ cd c/d
+    $ bd 2
+    $ ls
+    c
 
 Here's an animation also showing the completion functionality
 

--- a/bd.zsh
+++ b/bd.zsh
@@ -1,11 +1,31 @@
 bd () {
   (($#<1)) && {
     print -- "usage: $0 <name-of-any-parent-directory>"
+    print -- "       $0 <number-of-folders>"
     return 1
   } >&2
+  local num=${#${(ps:/:)${PWD}}}
+  local dest="./"
+
+  # If the user provided an integer, go up as many times as asked
+  if [[ "$1" = <-> ]]
+  then
+    if [[ $1 -gt $num ]]
+    then
+      print -- "bd: Error: Can not go up $1 times (not enough parent directories)"
+      return 1
+    fi
+    for i in {1..$1}
+    do
+      dest+="../"
+    done
+    cd $dest
+    return 0
+  fi
+
+  # else, find the correct parent directory
   # Get parents (in reverse order)
   local parents
-  local num=${#${(ps:/:)${PWD}}}
   local i
   for i in {$((num+1))..2}
   do
@@ -13,7 +33,6 @@ bd () {
   done
   parents=($parents "/")
   # Build dest and 'cd' to it
-  local dest="./"
   local parent
   foreach parent (${parents})
   do

--- a/tests/bd.t
+++ b/tests/bd.t
@@ -35,3 +35,13 @@ Lets also make sure we can jump beyond a 'space dir'
   $ bd a
   $ ls
   space dir
+
+If the provided argument is an integer, go up as many times as required.
+
+  $ cd 'space dir/f/g/h'
+  $ bd 1
+  $ ls
+  h
+  $ bd 2
+  $ ls
+  f


### PR DESCRIPTION
This is something I use frequently, maybe it can be of interest to others. 

With this change, you can do:

```zsh
$ cd a/b/c/d
$ bd 2
$ ls
c
```
I find it more readable and easier to use than aliases such as `cd ....`.

This has the side effect of not allowing the user to go back by name into a directory whose name is an integer. I can make it an option if it is an issue. 

