### PR TITLE
Except CWD from parents list

### DIFF
--- a/bd.zsh
+++ b/bd.zsh
@@ -13,7 +13,7 @@ bd () {
   # Get parents (in reverse order)
   local parents
   local i
-  for i in {$((num_folders_we_are_in+1))..2}
+  for i in {$num_folders_we_are_in..2}
   do
     parents=($parents "$(echo $PWD | cut -d'/' -f$i)")
   done
@@ -22,12 +22,12 @@ bd () {
   local parent
   foreach parent (${parents})
   do
+    dest+="../"
     if [[ $1 == $parent ]]
     then
       cd $dest
       return 0
     fi
-    dest+="../"
   done
 
   # If the user provided an integer, go up as many times as asked
@@ -55,7 +55,7 @@ _bd () {
   # Get parents (in reverse order)
   local num_folders_we_are_in=${#${(ps:/:)${PWD}}}
   local i
-  for i in {$((num_folders_we_are_in+1))..2}
+  for i in {$num_folders_we_are_in..2}
   do
     reply=($reply "`echo $PWD | cut -d'/' -f$i`")
   done

--- a/bd.zsh
+++ b/bd.zsh
@@ -12,21 +12,25 @@ bd () {
   # First try to find a folder with matching name (could potentially be a number)
   # Get parents (in reverse order)
   local parents
-  parents=(${(Oa)${(ps:/:)${PWD}}[1,-2]} "/")
+  local i
+  for i in {$((num_folders_we_are_in+1))..2}
+  do
+    parents=($parents "$(echo $PWD | cut -d'/' -f$i)")
+  done
+  parents=($parents "/")
   # Build dest and 'cd' to it
   local parent
   foreach parent (${parents})
   do
-    dest+="../"
     if [[ $1 == $parent ]]
     then
       cd $dest
       return 0
     fi
+    dest+="../"
   done
 
   # If the user provided an integer, go up as many times as asked
-  local i
   dest="./"
   if [[ "$1" = <-> ]]
   then
@@ -49,6 +53,12 @@ bd () {
 }
 _bd () {
   # Get parents (in reverse order)
-  reply=(${(Oa)${(ps:/:)${PWD}}[1,-2]} "/")
+  local num_folders_we_are_in=${#${(ps:/:)${PWD}}}
+  local i
+  for i in {$((num_folders_we_are_in+1))..2}
+  do
+    reply=($reply "`echo $PWD | cut -d'/' -f$i`")
+  done
+  reply=($reply "/")
 }
 compctl -V directories -K _bd bd

--- a/bd.zsh
+++ b/bd.zsh
@@ -12,25 +12,21 @@ bd () {
   # First try to find a folder with matching name (could potentially be a number)
   # Get parents (in reverse order)
   local parents
-  local i
-  for i in {$((num_folders_we_are_in+1))..2}
-  do
-    parents=($parents "$(echo $PWD | cut -d'/' -f$i)")
-  done
-  parents=($parents "/")
+  parents=(${(Oa)${(ps:/:)${PWD}}[1,-2]} "/")
   # Build dest and 'cd' to it
   local parent
   foreach parent (${parents})
   do
+    dest+="../"
     if [[ $1 == $parent ]]
     then
       cd $dest
       return 0
     fi
-    dest+="../"
   done
 
   # If the user provided an integer, go up as many times as asked
+  local i
   dest="./"
   if [[ "$1" = <-> ]]
   then
@@ -53,12 +49,6 @@ bd () {
 }
 _bd () {
   # Get parents (in reverse order)
-  local num_folders_we_are_in=${#${(ps:/:)${PWD}}}
-  local i
-  for i in {$((num_folders_we_are_in+1))..2}
-  do
-    reply=($reply "`echo $PWD | cut -d'/' -f$i`")
-  done
-  reply=($reply "/")
+  reply=(${(Oa)${(ps:/:)${PWD}}[1,-2]} "/")
 }
 compctl -V directories -K _bd bd

--- a/tests/bd.t
+++ b/tests/bd.t
@@ -61,3 +61,11 @@ Also document (with this test) the ambigious case
   $ bd 1
   $ ls
   2
+
+Exclude current working directory from parent list
+
+  $ mkdir -p aaa/bbb/aaa/ccc
+  $ cd aaa/bbb/aaa
+  $ bd aaa
+  $ ls
+  bbb


### PR DESCRIPTION
This is the patch for issue #16.
Current working directory is excluded from parent directory list.

Fixes #16 