### PR TITLE
Performance and completion improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tests/.zcompdump

--- a/tests/.zshenv
+++ b/tests/.zshenv
@@ -1,4 +1,6 @@
 test -f "$TESTDIR/.zcompdump" && rm "$TESTDIR/.zcompdump"
 
+autoload -Uz compinit && compinit
+
 source "$TESTDIR/../bd.zsh"
 export ENV_AUTHORIZATION_FILE="$PWD/.env_auth"


### PR DESCRIPTION
This PR adds performance improvements as well as improvements to the completion function.

Rather than using ZSH expansion flags to create an array of the parent directories and then only use that array to determine length, I am instead saving that array. This allows to later avoid using `cut` N times. In fact, `cut` does not need to be used at all any more.

The array is built in normal order, so the loop just loops over the array in reverse looking for a match to the requested destination (first parameter).

This PR also moves the completion system from the older compctl system to the newer compsys system. This allows any `matcher-list` settings to be respected. For example, I have my zsh matching setup so that it matches case insensitively and on substrings (i.e `de` would match `abcdef`). This brings bd in line with `cd` since ZSH's `cd` completion also respects the `matcher-list` settings.

I realized I have changed a lot here. Happy to discuss any questions/comments/concerns you may have!

I also ran your test cases from `tests\bd.t` and everything is working as expected!

Also, thanks for your work here!