### PR TITLE
Add styling to completion list

### DIFF
--- a/bd.zsh
+++ b/bd.zsh
@@ -82,7 +82,16 @@ _bd () {
     parentsReverse+=("${parents[${i}]}")
   done
 
-  compadd -V 'Parent directories' -M "${localMatcherList}" "$@" -- "${parentsReverse[@]}"
+  local expl
+  _wanted -V directories expl 'parent directories' \
+    compadd -M "${localMatcherList}" "$@" -- "${parentsReverse[@]}"
 }
 
 compdef _bd bd
+
+() {
+  local -a colors
+  zstyle -a ':completion:*' list-colors colors
+  local dir_color="${colors[(r)di=*]#di=}"
+  zstyle ':completion:*:*:bd:*:directories' list-colors "=*=${dir_color}"
+}


### PR DESCRIPTION
Uses the `list-colors` zstyle to add directory coloring to the completion list to look similar to `cd` completion. Resolves #17.

![image](https://github.com/user-attachments/assets/be3b31a6-2feb-4ff2-b6cf-18e452e5b84a)