### PR TITLE
Fix: check for empty zstyle and apply default

### DIFF
--- a/bd.zsh
+++ b/bd.zsh
@@ -91,7 +91,17 @@ compdef _bd bd
 
 () {
   local -a colors
-  zstyle -a ':completion:*' list-colors colors
-  local dir_color="${colors[(r)di=*]#di=}"
+  local dir_color='1;31' # hard-coded default in zsh/complist
+
+  # check for defined zstyle
+  if zstyle -a ':completion:*' list-colors colors && [[ "$#colors" -ne 0 ]]; then
+    local zstyle_color="${colors[(r)di=*]#di=}"
+    if [[ -n "$zstyle_color" ]]; then
+        dir_color="$zstyle_color"
+    fi
+  else
+    return
+  fi
+
   zstyle ':completion:*:*:bd:*:directories' list-colors "=*=${dir_color}"
 }


### PR DESCRIPTION
I didn't realize my previous commit only worked because I had LS_COLORS and a list-colors zstyle set, which is why it didn't work for you https://github.com/Tarrasch/zsh-bd/pull/25#issuecomment-2573555289. It should now always have the same color as `cd`.