### PR TITLE
feat: set default argument for bd to 1

### DIFF
--- a/bd.zsh
+++ b/bd.zsh
@@ -1,13 +1,6 @@
 # shellcheck shell=bash
 bd () {
-  (($#<1)) && {
-    printf -- 'usage: %s <name-of-any-parent-directory>\n' "${0}"
-    printf -- '       %s <number-of-folders>\n' "${0}"
-
-    return 1
-  } >&2
-
-  local requestedDestination="${1}"
+  local requestedDestination="${1:-1}"
   local -a parents=(${(ps:/:)"${PWD}"})
   local numParents
   local dest


### PR DESCRIPTION
Set the default value of the bd function's argument to 1 if not provided, removing the usage message and error return for missing arguments. This improves usability by allowing bd to be called without arguments to move up one directory by default.